### PR TITLE
Don't fail if title is put behind duration in EXTINF tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can be installed by adding `ex_m3u8` into your list of dependencies 
 ```elixir
 def deps do
   [
-    {:ex_m3u8, "~> 0.15.3"}
+    {:ex_m3u8, "~> 0.15.4"}
   ]
 end
 ```

--- a/lib/ex_m3u8/deserializer/parser.ex
+++ b/lib/ex_m3u8/deserializer/parser.ex
@@ -173,7 +173,7 @@ defmodule ExM3U8.Deserializer.Parser do
 
   defp do_parse(["#EXTINF:" <> value | lines], acc, opts) do
     case Float.parse(value) do
-      {duration, ","} ->
+      {duration, "," <> _maybe_title} ->
         parse_segment(duration, lines, acc, opts)
 
       :error ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExM3U8.MixProject do
   use Mix.Project
 
-  @version "0.15.3"
+  @version "0.15.4"
   @github_url "https://github.com/membraneframework/ex_m3u8"
 
   def project do


### PR DESCRIPTION
As specified in the [HLS RFC](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.1), EXTINF tag might contain optional "title" field.