### PR TITLE
Add GitHub Action to close issues automatically

### DIFF
--- a/.github/ISSUE_TEMPLATE/please--open-new-issues-in-membranefranework-membrane_core.md
+++ b/.github/ISSUE_TEMPLATE/please--open-new-issues-in-membranefranework-membrane_core.md
@@ -1,0 +1,12 @@
+---
+name: Please, open new issues in membranefranework/membrane_core
+about: New issues related to this repo should be opened there
+title: "[DO NOT OPEN]"
+labels: ''
+assignees: ''
+
+---
+
+Please, do not open this issue here. Open it in the [membrane_core](https://github.com/membraneframework/membrane_core) repository instead.
+
+Thanks for helping us grow :)

--- a/.github/actions/close_issue/action.yml
+++ b/.github/actions/close_issue/action.yml
@@ -1,0 +1,50 @@
+name: 'Close issue when opened'
+description: 'Closes a newly opened issue, tags it and puts it in the proper column in Smackore project board.'
+inputs:
+  GITHUB_TOKEN:
+    description: 'GitHub token'
+    required: true
+  ISSUE_URL:
+    description: 'Issue URL'
+    required: true
+  ISSUE_NUMBER:
+    description: 'Issue number'
+    required: true
+  REPOSITORY:
+    description: 'Repository'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: '26.1'
+        elixir-version: '1.15.6'
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        repository: membraneframework/membrane_core
+    - name: Create ticket and close issue
+      run: |
+        export PROJECT_NUMBER=19
+        export PROJECT_ID=PVT_kwDOAYE_z84AWEIB
+        export STATUS_FIELD_ID=PVTSSF_lADOAYE_z84AWEIBzgOGd1k
+        export TARGET_COLUMN_ID=fa223107
+        export CORE_URL=https://github.com/membraneframework/membrane_core
+        export ISSUE_CLOSE_COMMENT="Issues related to $REPOSITORY are stored in [membrane_core]($CORE_URL), so we close this issue here and we encourage you to open it [there]($CORE_URL)."
+
+        gh issue edit $ISSUE_URL --add-project "Smackore"
+        sleep 10        
+
+        export TICKET_ID=$(gh project item-list $PROJECT_NUMBER --owner membraneframework --format json --limit 10000000 | python ./scripts/python/get_ticket_id.py "$ISSUE_URL")
+        gh issue close $ISSUE_URL --comment "$ISSUE_CLOSE_COMMENT" --reason "not planned"
+        sleep 10
+
+        gh project item-edit --id $TICKET_ID --field-id $STATUS_FIELD_ID --project-id $PROJECT_ID --single-select-option-id $TARGET_COLUMN_ID
+      env:
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        ISSUE_URL: ${{ inputs.ISSUE_URL }}
+        ISSUE_NUMBER: ${{ inputs.ISSUE_NUMBER }}
+        REPOSITORY: ${{ inputs.REPOSITORY }}
+      shell: bash


### PR DESCRIPTION
This action closes newly opened issues, tags them, and organizes them in the Smackore project board.